### PR TITLE
Fixed length and time conversions requiring delimiters

### DIFF
--- a/sandpiper/common/time.py
+++ b/sandpiper/common/time.py
@@ -14,7 +14,7 @@ TimezoneType = Union[pytz.tzinfo.StaticTzInfo, pytz.tzinfo.DstTzInfo]
 
 time_pattern = re.compile(
     r'^(?P<hour>[0-2]?\d)'
-    r'(?::(?P<minute>\d{2}))?'
+    r'(?::*(?P<minute>\d{2}))?'
     r'\s*'
     r'(?:(?P<period_am>a|am)|(?P<period_pm>p|pm))?$',
     re.I

--- a/sandpiper/conversion/unit_conversion.py
+++ b/sandpiper/conversion/unit_conversion.py
@@ -47,7 +47,7 @@ unit_map = bidict({
 })
 
 imperial_height_pattern = re.compile(
-    r'^(?=.)(?:(?P<foot>[\d]+)\')?(?:(?(foot) |)(?P<inch>[\d.]+)\")?$')
+    r'^((?P<foot>[\d]+)\')?(\s)*((?P<inch>[\d]+)\")?$')
 
 
 def imperial_metric(quantity_str: str) -> Optional[Tuple[Quantity, Quantity]]:

--- a/sandpiper/tests/conversion.py
+++ b/sandpiper/tests/conversion.py
@@ -57,6 +57,16 @@ class TestConversion(DiscordMockingTestCase):
         self.assertIn('1.88 m', msgs[0])
 
         msgs = await self.dispatch_msg_get_msgs(
+            "I'm only {5'11\"} though!")
+        self.assertIn('5.92 ft', msgs[0])
+        self.assertIn('1.80 m', msgs[0])
+
+        msgs = await self.dispatch_msg_get_msgs(
+            "Is that a {33ft} boat, TJ?")
+        self.assertIn('33.00 ft', msgs[0])
+        self.assertIn('10.06 m', msgs[0])
+
+        msgs = await self.dispatch_msg_get_msgs(
             "Lou lives about {15km} from me and TJ's staying at a hotel "
             "{2.5km} away, so he and I are gonna meet up and drive over to "
             "Lou."

--- a/sandpiper/tests/conversion.py
+++ b/sandpiper/tests/conversion.py
@@ -123,6 +123,20 @@ class TestConversion(DiscordMockingTestCase):
 
         self.msg.author.id = american_user
         msgs = await self.dispatch_msg_get_msgs(
+            "I get off work at {330pm}")
+        self.assertRegex(msgs[0], r'Europe/Amsterdam.+9:30 PM')
+        self.assertRegex(msgs[0], r'Europe/London.+8:30 PM')
+        self.assertRegex(msgs[0], r'America/New_York.+3:30 PM')
+
+        self.msg.author.id = american_user
+        msgs = await self.dispatch_msg_get_msgs(
+            "In 24-hour time that's {1530}")
+        self.assertRegex(msgs[0], r'Europe/Amsterdam.+9:30 PM')
+        self.assertRegex(msgs[0], r'Europe/London.+8:30 PM')
+        self.assertRegex(msgs[0], r'America/New_York.+3:30 PM')
+
+        self.msg.author.id = american_user
+        msgs = await self.dispatch_msg_get_msgs(
             "Dude, it's {midnight} :gobed:!")
         self.assertRegex(msgs[0], r'Europe/Amsterdam.+6:00 AM')
         self.assertRegex(msgs[0], r'Europe/London.+5:00 AM')


### PR DESCRIPTION
Closes #18

Tested the new regex with the following cases:

> 5'7"
> 5' 7"
> 7"
> 5'
> 55'
> 30.00 °F

![Evidence](https://i.imgur.com/PZ8gNBI.png)

Also Closes #19

Tested the new regex with the following cases:

> 3pm
> 3:00pm
> 300pm
> 3 pm
> 3:00 pm
> 300 pm
> 300
> 1730
> 17:30

![Evidence](https://i.imgur.com/pk1dn0m.png)