### PR TITLE
Python 3.9 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Project
+/sandpiper/config.json
+/sandpiper/logs
+*.db
+*.db-journal
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -131,8 +137,6 @@ dmypy.json
 # JetBrains
 .idea/
 
-# Project
-/sandpiper/config.json
-/sandpiper/logs
-*.db
-*.db-journal
+# Profiling
+prof/
+*.prof

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ python -m pip install -r requirements-dev.txt
 
 ```bash
 python -m pytest --pyargs sandpiper
+# Add --profile and/or --profile-svg to run with profiling
 ```
 
 #### Run tests with code coverage

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/hawkpath/sandpiper.git
 cd sandpiper
 ```
 
-With Python 3.8+, create a virtual environment and install dependencies.
+With Python 3.9+, create a virtual environment and install dependencies.
 
 ```shell script
 python -m venv venv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 
 coverage>=5.3
 pytest
+pytest-profiling

--- a/sandpiper/common/discord.py
+++ b/sandpiper/common/discord.py
@@ -1,6 +1,6 @@
 from datetime import date
 import logging
-from typing import *
+from typing import Optional
 
 import discord
 from discord.ext.commands import BadArgument, Command
@@ -73,7 +73,7 @@ def privacy_handler(privacy_str: str) -> PrivacyType:
 def find_user_in_mutual_guilds(
     client: discord.Client, whos_looking: int, for_whom: int,
     *, short_circuit: bool = False
-) -> List[discord.Member]:
+) -> list[discord.Member]:
     """
     Find a user who shares mutual guild's with someone else.
 
@@ -96,7 +96,7 @@ def find_user_in_mutual_guilds(
 
 
 def find_users_by_username(client: discord.Client,
-                           name: str) -> [List[Tuple[int, str]]]:
+                           name: str) -> [list[tuple[int, str]]]:
     """
     Search for users by their Discord username.
 
@@ -116,7 +116,7 @@ def find_users_by_username(client: discord.Client,
 def find_users_by_display_name(
     client: discord.Client, whos_looking: int, name: str,
     *, guild: Optional[discord.Guild] = None,
-) -> [List[Tuple[int, str]]]:
+) -> [list[tuple[int, str]]]:
     """
     Search for users by their display name (nickname in a guild). You may pass
     in a guild to optimize the search by limiting to only that guild.

--- a/sandpiper/common/embeds.py
+++ b/sandpiper/common/embeds.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Tuple, Union
+from collections import Iterable
+from typing import Union
 
 import discord
 
@@ -6,7 +7,7 @@ from .misc import join
 
 __all__ = ['Embeds']
 
-FieldType = Tuple[str, str, bool]
+FieldType = tuple[str, str, bool]
 
 
 class Embeds:

--- a/sandpiper/common/misc.py
+++ b/sandpiper/common/misc.py
@@ -1,4 +1,5 @@
-from typing import *
+from collections import Iterable
+from typing import Union
 
 __all__ = ('join', 'prune', 'RuntimeMessages')
 
@@ -15,8 +16,8 @@ class RuntimeMessages:
 
     __slots__ = ('info', 'exceptions')
 
-    info: List[str]
-    exceptions: List[Exception]
+    info: list[str]
+    exceptions: list[Exception]
 
     def __init__(self):
         self.info = []

--- a/sandpiper/common/time.py
+++ b/sandpiper/common/time.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import datetime as dt
 import re
-from typing import *
+from typing import Optional, Union, cast
 
 from fuzzywuzzy import fuzz, process as fuzzy_process
 import pytz
@@ -113,7 +113,7 @@ def utc_now() -> dt.datetime:
     return local_tz.localize(dt.datetime.now())
 
 
-def parse_time(time_str: str) -> Tuple[dt.time, Optional[str], bool]:
+def parse_time(time_str: str) -> tuple[dt.time, Optional[str], bool]:
     """
     Parse a string as a time specifier of the general format "12:34 PM".
     Can optionally include a timezone name.
@@ -236,7 +236,7 @@ def localize_time_to_datetime(
 
 @dataclass
 class TimezoneMatches:
-    matches: List[Tuple[str, int]] = None
+    matches: list[tuple[str, int]] = None
     best_match: Optional[TimezoneType] = False
     has_multiple_best_matches: bool = False
 
@@ -260,7 +260,7 @@ def fuzzy_match_timezone(
     # The regular token_sort_ratio just feels weird because it doesn't support
     # substrings. Searching "Amst" would pick "GMT" rather than "Amsterdam".
     # The _set_ratio methods are totally unusable.
-    matches: List[Tuple[str, int]] = fuzzy_process.extractBests(
+    matches: list[tuple[str, int]] = fuzzy_process.extractBests(
         tz_str, pytz.common_timezones, scorer=fuzz.partial_token_sort_ratio,
         score_cutoff=lower_score_cutoff, limit=limit
     )

--- a/sandpiper/config.py
+++ b/sandpiper/config.py
@@ -3,7 +3,7 @@ import json
 import logging
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Union
 
 DEFAULTS = {
   "bot": {
@@ -30,7 +30,7 @@ class ConfigError(Exception):
     pass
 
 
-def get_default(config: Dict[str, Any], category: str, key: str):
+def get_default(config: dict[str, Any], category: str, key: str):
     try:
         return config[category][key]
     except KeyError:
@@ -48,7 +48,7 @@ class Config:
         command_prefix: str
         description: str
 
-        def __init__(self, config: Dict[str, Any]):
+        def __init__(self, config: dict[str, Any]):
             """Parse bot-specific config"""
 
             self.command_prefix = get_default(config, 'bot', 'command_prefix')
@@ -78,7 +78,7 @@ class Config:
         _allowed_whens = ('S', 'M', 'H', 'D', 'midnight')
         _allowed_logging_levels = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
 
-        def __init__(self, config: Dict[str, Any]):
+        def __init__(self, config: dict[str, Any]):
             """Parse logging-specific config"""
 
             self.sandpiper_logging_level = get_default(
@@ -129,13 +129,13 @@ class Config:
             )
             self.handler.setFormatter(self.formatter)
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         """Parse config"""
         self.bot = self.Bot(config)
         self.logging = self.Logging(config)
 
     @classmethod
-    def load_json(cls, config_path: Union[Path, str]) -> Tuple[str, Config]:
+    def load_json(cls, config_path: Union[Path, str]) -> tuple[str, Config]:
         """
         Load bot config from a json file.
 
@@ -145,7 +145,7 @@ class Config:
         """
 
         with open(config_path) as f:
-            config_json: Dict[str, Any] = json.load(f)
+            config_json: dict[str, Any] = json.load(f)
 
         if 'bot_token' not in config_json:
             raise ConfigError('bot_token missing')

--- a/sandpiper/conversion/cog.py
+++ b/sandpiper/conversion/cog.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 import logging
 import re
-from typing import *
+from typing import NoReturn
 
 import discord
 import discord.ext.commands as commands
@@ -46,8 +46,8 @@ class Conversion(commands.Cog):
         await self.convert_measurements(msg.channel, conversion_strs)
 
     async def convert_time(
-            self, msg: discord.Message, time_strs: List[Tuple[str, str]]
-    ) -> List[Tuple[str, str]]:
+            self, msg: discord.Message, time_strs: list[tuple[str, str]]
+    ) -> list[tuple[str, str]]:
         """
         Convert a list of time strings (like "5:45 PM") to different users'
         timezones and reply with the conversions.
@@ -106,7 +106,7 @@ class Conversion(commands.Cog):
 
     async def convert_measurements(
             self, channel: discord.TextChannel,
-            quantity_strs: List[Tuple[str, str]]
+            quantity_strs: list[tuple[str, str]]
     ) -> NoReturn:
         """
         Convert a list of quantity strings (like "5 km") between imperial and
@@ -118,7 +118,7 @@ class Conversion(commands.Cog):
         """
 
         conversions = []
-        failed: List[Tuple[str, str]] = []
+        failed: list[tuple[str, str]] = []
         runtime_msgs = RuntimeMessages()
         for qstr, unit in quantity_strs:
             q = unit_conversion.convert_measurement(

--- a/sandpiper/conversion/time_conversion.py
+++ b/sandpiper/conversion/time_conversion.py
@@ -1,7 +1,7 @@
-from collections import defaultdict
+from collections import Iterable, defaultdict
 import datetime as dt
 import logging
-from typing import *
+from typing import Optional, Union, cast
 
 import discord
 
@@ -17,8 +17,8 @@ __all__ = (
 
 logger = logging.getLogger('sandpiper.conversion.time_conversion')
 
-T_ConvertedTimes = List[Tuple[str, List[dt.datetime]]]
-T_ConvertedTimesGroupedUnderInputTimezones = List[Tuple[Optional[str], T_ConvertedTimes]]
+T_ConvertedTimes = list[tuple[str, list[dt.datetime]]]
+T_ConvertedTimesGroupedUnderInputTimezones = list[tuple[Optional[str], T_ConvertedTimes]]
 
 
 class UserTimezoneUnset(Exception):
@@ -48,7 +48,7 @@ def _get_timezone(name: str) -> Optional[TimezoneType]:
     return matches.best_match or None
 
 
-async def _get_guild_timezones(db: Database, guild: discord.Guild) -> Set[TimezoneType]:
+async def _get_guild_timezones(db: Database, guild: discord.Guild) -> set[TimezoneType]:
     """
     Get all user timezones from the given guild.
 
@@ -64,7 +64,7 @@ async def _get_guild_timezones(db: Database, guild: discord.Guild) -> Set[Timezo
 
 
 async def _convert_times(
-        times: List[dt.datetime],
+        times: list[dt.datetime],
         out_timezones: Union[TimezoneType, Iterable[TimezoneType]]
 ) -> T_ConvertedTimes:
     """
@@ -90,11 +90,11 @@ async def _convert_times(
 
 async def convert_time_to_user_timezones(
         db: Database, user_id: int, guild: discord.Guild,
-        time_strs: List[Tuple[str, str]],
+        time_strs: list[tuple[str, str]],
         *, runtime_msgs: RuntimeMessages
-) -> Tuple[
+) -> tuple[
     T_ConvertedTimesGroupedUnderInputTimezones,
-    List[Tuple[str, str]]
+    list[tuple[str, str]]
 ]:
     """
     Convert times.
@@ -124,10 +124,10 @@ async def convert_time_to_user_timezones(
     # Each datetime under a given timezone will be converted to that timezone
     # only. The None key is a special case, where each datetime mapped to it
     # will be converted to all user timezones in the database
-    out_timezone_map: Dict[Optional[TimezoneType], List[dt.datetime]] = (
+    out_timezone_map: dict[Optional[TimezoneType], list[dt.datetime]] = (
         defaultdict(list)
     )
-    failed: List[Tuple[str, str]] = []  # Strings that should pass on to unit conversion
+    failed: list[tuple[str, str]] = []  # Strings that should pass on to unit conversion
     user_tz = None
     for tstr, timezone_out_str in time_strs:
         try:

--- a/sandpiper/conversion/unit_conversion.py
+++ b/sandpiper/conversion/unit_conversion.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 import logging
 import re
-from typing import *
+from typing import Union
 
 from pint import UndefinedUnitError as PintUndefinedUnitError
 from pint import UnitRegistry, Unit
@@ -130,7 +130,7 @@ class UnmappedUnitError(Exception):
 def convert_measurement(
         quantity_str: str, unit: str = None,
         *, runtime_msgs: RuntimeMessages = None
-) -> Union[Tuple[Quantity, Quantity], Decimal, None]:
+) -> Union[tuple[Quantity, Quantity], Decimal, None]:
     """
     Parse and convert a quantity string between imperial and metric
 

--- a/sandpiper/conversion/unit_map.py
+++ b/sandpiper/conversion/unit_map.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
-from typing import *
+
+from typing import Generic, TypeVar
 
 T = TypeVar('T')
 
 
 class UnitMap(Generic[T]):
 
-    _two_way: Dict[T, T]
-    _one_way: Dict[T, T]
+    _two_way: dict[T, T]
+    _one_way: dict[T, T]
 
     def __init__(
-            self, *, two_way: Dict[T, T], one_way: Dict[T, T] = None
+            self, *, two_way: dict[T, T], one_way: dict[T, T] = None
     ):
         if not isinstance(two_way, dict):
             raise ValueError(f"two_way must be a dict")
@@ -41,7 +42,7 @@ class UnitMap(Generic[T]):
         return key in self._two_way or key in self._one_way
 
     @staticmethod
-    def _create_bidict(dict_: Dict[T, T]) -> Dict[T, T]:
+    def _create_bidict(dict_: dict[T, T]) -> dict[T, T]:
         out = {}
         for a, b in dict_.items():
             out[a] = b

--- a/sandpiper/help.py
+++ b/sandpiper/help.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterable
 import itertools
-from typing import *
 
 from discord.ext.commands import DefaultHelpCommand, Group, Command, Cog
 

--- a/sandpiper/tests/_test_helpers.py
+++ b/sandpiper/tests/_test_helpers.py
@@ -1,4 +1,4 @@
-from typing import *
+from typing import Literal, NoReturn, Optional, Union, overload
 import unittest
 import unittest.mock as mock
 
@@ -74,10 +74,10 @@ class DiscordMockingTestCase(unittest.IsolatedAsyncioTestCase):
 
     # noinspection PyPropertyAccess
     def init_mock_userdata(self):
-        self.guilds: List[mock.Mock] = []
-        self.users: List[mock.Mock] = []
-        self.guilds_map: Dict[int, mock.Mock] = {}
-        self.users_map: Dict[int, mock.Mock] = {}
+        self.guilds: list[mock.Mock] = []
+        self.users: list[mock.Mock] = []
+        self.guilds_map: dict[int, mock.Mock] = {}
+        self.users_map: dict[int, mock.Mock] = {}
 
         patcher = mock.patch.object(self.bot, 'get_user')
         get_user = patcher.start()
@@ -183,7 +183,7 @@ class DiscordMockingTestCase(unittest.IsolatedAsyncioTestCase):
     # region Message dispatching and command invocation
 
     @staticmethod
-    def get_embeds(mock_: MagicMock_) -> List[discord.Embed]:
+    def get_embeds(mock_: MagicMock_) -> list[discord.Embed]:
         """
         :param mock_: a mock ``send`` method
         :return: a list of embeds sent in each message
@@ -194,7 +194,7 @@ class DiscordMockingTestCase(unittest.IsolatedAsyncioTestCase):
         ]
 
     @staticmethod
-    def get_contents(mock_: MagicMock_) -> List[str]:
+    def get_contents(mock_: MagicMock_) -> list[str]:
         """
         :param mock_: a mock ``send`` method
         :return: a list of each message's contents
@@ -224,7 +224,7 @@ class DiscordMockingTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def invoke_cmd_get_embeds(
             self, message_content: str
-    ) -> List[discord.Embed]:
+    ) -> list[discord.Embed]:
         """
         Invoke a command with ``invoke_cmd`` and return the embeds sent back.
 
@@ -255,13 +255,13 @@ class DiscordMockingTestCase(unittest.IsolatedAsyncioTestCase):
     @overload
     async def dispatch_msg_get_contents(
             self, message_content: str
-    ) -> List[str]:
+    ) -> list[str]:
         pass
 
     @overload
     async def dispatch_msg_get_contents(
             self, message_content: str, only_one: Literal[False]
-    ) -> List[str]:
+    ) -> list[str]:
         pass
 
     @overload
@@ -272,7 +272,7 @@ class DiscordMockingTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def dispatch_msg_get_contents(
             self, message_content: str, only_one = False
-    ) -> Union[List[str], str]:
+    ) -> Union[list[str], str]:
         """
         Use ``dispatch_msg`` to dispatch ``self.msg`` to the client and
         return the message contents that were sent back.
@@ -293,13 +293,13 @@ class DiscordMockingTestCase(unittest.IsolatedAsyncioTestCase):
     @overload
     async def dispatch_msg_get_embeds(
             self, message_content: str
-    ) -> List[discord.Embed]:
+    ) -> list[discord.Embed]:
         pass
 
     @overload
     async def dispatch_msg_get_embeds(
             self, message_content: str, only_one: Literal[False] = False
-    ) -> List[discord.Embed]:
+    ) -> list[discord.Embed]:
         pass
 
     @overload
@@ -310,7 +310,7 @@ class DiscordMockingTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def dispatch_msg_get_embeds(
             self, message_content: str, only_one = False
-    ) -> Union[List[discord.Embed], discord.Embed]:
+    ) -> Union[list[discord.Embed], discord.Embed]:
         """
         Use ``dispatch_msg`` to dispatch ``self.msg`` to the client and
         return a list of embeds that were sent back.

--- a/sandpiper/tests/test_common_time.py
+++ b/sandpiper/tests/test_common_time.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import *
+from typing import Optional
 import unittest
 import unittest.mock as mock
 

--- a/sandpiper/tests/test_conversion.py
+++ b/sandpiper/tests/test_conversion.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import *
+from typing import Optional, Union
 import unittest
 import unittest.mock as mock
 
@@ -325,7 +325,7 @@ class TestTimeConversion(DiscordMockingTestCase):
         bot.add_cog(Conversion(bot))
         bot.add_cog(UserData(bot))
 
-    async def add_timezone_user(self, timezone: str) -> Tuple[int, dt.datetime]:
+    async def add_timezone_user(self, timezone: str) -> tuple[int, dt.datetime]:
         uid = self.new_user_id()
         tz = pytz.timezone(timezone)
         now = utc_now().astimezone(tz)

--- a/sandpiper/user_data/database.py
+++ b/sandpiper/user_data/database.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 import datetime
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from ..common.time import TimezoneType
 from .enums import PrivacyType
@@ -31,11 +31,11 @@ class Database(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    async def find_users_by_preferred_name(self, name: str) -> List[Tuple[int, str]]:
+    async def find_users_by_preferred_name(self, name: str) -> list[tuple[int, str]]:
         pass
 
     @abstractmethod
-    async def get_all_timezones(self) -> List[Tuple[int, TimezoneType]]:
+    async def get_all_timezones(self) -> list[tuple[int, TimezoneType]]:
         pass
 
     @abstractmethod

--- a/sandpiper/user_data/database_sqlite.py
+++ b/sandpiper/user_data/database_sqlite.py
@@ -71,7 +71,7 @@ class DatabaseSQLite(Database):
         except aiosqlite.Error:
             logger.error('Failed to create indices', exc_info=True)
 
-    async def find_users_by_preferred_name(self, name: str) -> List[Tuple[int, str]]:
+    async def find_users_by_preferred_name(self, name: str) -> list[tuple[int, str]]:
         logger.info(f'Finding users by preferred name (name={name!r})')
         if name == '':
             logger.info('Skipping empty string')
@@ -85,11 +85,11 @@ class DatabaseSQLite(Database):
         args = {'name': f'%{name}%', 'privacy': PrivacyType.PUBLIC}
         try:
             cur = await self._con.execute(stmt, args)
-            return cast(List[Tuple[int, str]], await cur.fetchall())
+            return cast(list[tuple[int, str]], await cur.fetchall())
         except aiosqlite.Error:
             logger.error('Failed to find users by name', exc_info=True)
 
-    async def get_all_timezones(self) -> List[Tuple[int, TimezoneType]]:
+    async def get_all_timezones(self) -> list[tuple[int, TimezoneType]]:
         logger.info(f'Getting all user timezones')
         stmt = '''
             SELECT user_id, timezone FROM user_data


### PR DESCRIPTION
Closes #34. The only major changes were updating all generic types to use standard collections (PEP 585).